### PR TITLE
fix: Helper texts are now displayed on chained fields

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -12,6 +12,7 @@
       :via-resource-id="viaResourceId"
       :via-relationship="viaRelationship"
       :shown-via-new-relation-modal="shownViaNewRelationModal"
+      :show-help-text="true"
       @file-deleted="$emit('update-last-retrieved-at-timestamp')"  
       @hook:updated="emitUpdated(field)" 
       @hook:beforeDestroy="emitBeforeDestroy(field)" 


### PR DESCRIPTION
As it stands the helper texts are not displayed on some fields. This fixes that!